### PR TITLE
using node-pty to support windows builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "json": "^9.0.3",
-    "pty.js": "^0.3.0",
+    "node-pty": "^0.6.3",
     "tape": "^4.4.0"
   },
   "repository": {

--- a/test/basic.test.js
+++ b/test/basic.test.js
@@ -20,9 +20,8 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
 */
-
 const mod_tape = require('tape');
-const mod_pty = require('pty.js');
+const mod_pty = require('node-pty');
 
 mod_tape.test('get a password', function (t) {
 	var term = mod_pty.spawn('node', ['./test/getpass.js'], {


### PR DESCRIPTION
node-pty is a fork of pty.js which works on windows machines - tested on both windows and centos - the windows fails because getpass doesn't work on windows.

Some of our windows developers use modules that depend on getpass and this is causing us problems - could you review this pull request and see if you could publish to npm if you agree with it?

Thanks in advance